### PR TITLE
Symorton/ec commit signer

### DIFF
--- a/src/crypto/CommitSigner.ts
+++ b/src/crypto/CommitSigner.ts
@@ -1,10 +1,10 @@
-import { PrivateKey, JwsToken, CryptoFactory, RsaCryptoSuite } from '@decentralized-identity/did-auth-jose';
+import { PrivateKey, JwsToken, CryptoFactory, RsaCryptoSuite, CryptoSuite } from '@decentralized-identity/did-auth-jose';
 import ICommitSigner from './ICommitSigner';
 import Commit from '../Commit';
 import SignedCommit from '../SignedCommit';
 import objectAssign = require('object-assign');
 
-interface RsaCommitSignerOptions {
+interface CommitSignerOptions {
 
   /** The DID of the identity that will the commit. */
   did: string;
@@ -12,19 +12,28 @@ interface RsaCommitSignerOptions {
   /** The private key to be used to sign the commit. */
   key: PrivateKey;
 
+  /** The CryptoSuite to be used to for the algorithm to use to sign the commit */
+  cryptoSuite?: CryptoSuite;
+
 }
 
 /**
- * Class which can apply a RSA signature to a commit.
+ * Class which can apply a signature to a commit.
  */
-export default class RsaCommitSigner implements ICommitSigner {
+export default class CommitSigner implements ICommitSigner {
 
   private did: string;
   private key: PrivateKey;
+  private cryptoSuite: CryptoSuite;
 
-  constructor(options: RsaCommitSignerOptions) {
+  constructor(options: CommitSignerOptions) {
     this.did = options.did;
     this.key = options.key;
+    if (!options.cryptoSuite) {
+      this.cryptoSuite = new RsaCryptoSuite();
+    } else {
+      this.cryptoSuite = options.cryptoSuite;
+    }
   }
 
   /**
@@ -41,7 +50,7 @@ export default class RsaCommitSigner implements ICommitSigner {
       iss: this.did,
     });
 
-    const jws = new JwsToken(commit.getPayload(), new CryptoFactory([new RsaCryptoSuite()]));
+    const jws = new JwsToken(commit.getPayload(), new CryptoFactory([this.cryptoSuite]));
     const signed = await jws.sign(this.key, finalProtectedHeaders as any); // TODO: Need to broaden TypeScript definition of JwsToken.sign().
 
     const [outputHeaders, outputPayload, outputSignature] = signed.split('.');

--- a/src/example.ts
+++ b/src/example.ts
@@ -2,7 +2,7 @@ import RsaPrivateKey from '@decentralized-identity/did-auth-jose/dist/lib/crypto
 import { HttpResolver } from '@decentralized-identity/did-common-typescript';
 import HubSession from './HubSession';
 import HubWriteRequest from './requests/HubWriteRequest';
-import RsaCommitSigner from './crypto/RsaCommitSigner';
+import CommitSigner from './crypto/CommitSigner';
 import Commit from './Commit';
 import HubObjectQueryRequest from './requests/HubObjectQueryRequest';
 import HubCommitQueryRequest from './requests/HubCommitQueryRequest';
@@ -60,7 +60,7 @@ async function runExample() {
       },
     });
 
-    const signer = new RsaCommitSigner({
+    const signer = new CommitSigner({
       did: DID,
       key: privateKey,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Cryptography
-export { default as RsaCommitSigner } from './crypto/RsaCommitSigner';
+export { default as CommitSigner } from './crypto/CommitSigner';
 export { default as ICommitSigner } from './crypto/ICommitSigner';
 
 // Requests

--- a/tests/crypto/CommitSigner.spec.ts
+++ b/tests/crypto/CommitSigner.spec.ts
@@ -1,13 +1,14 @@
 import { ICommitProtectedHeaders } from '@decentralized-identity/hub-common-js';
-import RsaCommitSigner from '../../src/crypto/RsaCommitSigner';
+import CommitSigner from './CommitSigner';
 import RsaPrivateKey from '@decentralized-identity/did-auth-jose/dist/lib/crypto/rsa/RsaPrivateKey';
-import Commit from '../../src/Commit';
+import { EcPrivateKey, Secp256k1CryptoSuite } from '@decentralized-identity/did-auth-jose';
+import Commit from '../Commit';
 
-describe('RsaCommitSigner', () => {
+describe('CommitSigner', () => {
 
   describe('sign()', () => {
 
-    it('should sign a commit', async () => {
+    it('should sign a commit using Rsa', async () => {
       const testDid = 'did:example:person.id';
       const testKid = `${testDid}#key-1`;
       const testKey = await RsaPrivateKey.generatePrivateKey(testKid);
@@ -32,9 +33,53 @@ describe('RsaCommitSigner', () => {
         payload
       });
 
-      const signer = new RsaCommitSigner({
+      const signer = new CommitSigner({
         did: testDid,
         key: testKey
+      });
+
+      const signedCommit = await signer.sign(commit);
+
+      expect(signedCommit.getPayload()).toEqual(payload);
+
+      const signedProtectedHeaders = signedCommit.getProtectedHeaders();
+      Object.keys(protectedHeaders).forEach((headerKey) => {
+        expect((signedProtectedHeaders as any)[headerKey]).toEqual((protectedHeaders as any)[headerKey]);
+      })
+
+      expect(signedProtectedHeaders.iss).toEqual(testDid);
+      expect(signedProtectedHeaders.kid).toEqual(testKid);
+    });
+
+    it('should sign a commit using EC', async () => {
+      const testDid = 'did:example:person.id';
+      const testKid = `${testDid}#key-1`;
+      const testKey = await EcPrivateKey.generatePrivateKey(testKid);
+
+      const protectedHeaders: Partial<ICommitProtectedHeaders> = {
+        interface: 'Collections',
+        context: 'schema.org',
+        type: 'MusicPlaylist',
+        operation: 'create',
+        committed_at: '2019-01-01',
+        commit_strategy: 'basic',
+        sub: 'did:example:sub.id',
+        // iss and kid left out intentionally
+      };
+
+      const payload = {
+        name: "Test"
+      };
+
+      const commit = new Commit({
+        protected: protectedHeaders,
+        payload
+      });
+
+      const signer = new CommitSigner({
+        did: testDid,
+        key: testKey,
+        cryptoSuite: new Secp256k1CryptoSuite()
       });
 
       const signedCommit = await signer.sign(commit);
@@ -70,7 +115,7 @@ describe('RsaCommitSigner', () => {
         }
       });
 
-      const signer = new RsaCommitSigner({
+      const signer = new CommitSigner({
         did: testDid,
         key: testKey
       });

--- a/tests/crypto/CommitSigner.spec.ts
+++ b/tests/crypto/CommitSigner.spec.ts
@@ -1,8 +1,8 @@
 import { ICommitProtectedHeaders } from '@decentralized-identity/hub-common-js';
-import CommitSigner from './CommitSigner';
+import CommitSigner from '../../src/crypto/CommitSigner';
 import RsaPrivateKey from '@decentralized-identity/did-auth-jose/dist/lib/crypto/rsa/RsaPrivateKey';
 import { EcPrivateKey, Secp256k1CryptoSuite } from '@decentralized-identity/did-auth-jose';
-import Commit from '../Commit';
+import Commit from '../../src/Commit';
 
 describe('CommitSigner', () => {
 


### PR DESCRIPTION
abstracted out CryptoSuite in CommitSigner so that there other key types besides RSA can be used to sign commits. RSA will be the default signing algorithm if there is no cryptosuite in the options.